### PR TITLE
Mogelijkheid om een foto te maken.

### DIFF
--- a/AndroidApplicatie/.idea/gradle.xml
+++ b/AndroidApplicatie/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/AndroidApplicatie/app/src/main/AndroidManifest.xml
+++ b/AndroidApplicatie/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.projectd">
 
+    <!--Toestemming om camera te gebruiken en gemaakte foto op te slaan op externe opslag.-->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -9,12 +13,21 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".CameraActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity android:name=".MainActivity">
+            <!-- tijdelijk uitgecomment zodat tijdens maken van deze feature CameraActivity entrypoint is.
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            -->
         </activity>
     </application>
 

--- a/AndroidApplicatie/app/src/main/java/com/example/projectd/CameraActivity.java
+++ b/AndroidApplicatie/app/src/main/java/com/example/projectd/CameraActivity.java
@@ -1,0 +1,90 @@
+package com.example.projectd;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+
+import android.Manifest;
+import android.content.ContentValues;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.MediaStore;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.Toast;
+
+public class CameraActivity extends AppCompatActivity {
+
+    //Permission code voor toestemming camera & opslag
+    private static final int PERMISSION_CODE = 1000;
+    private static final int IMAGE_CAPTURE_CODE = 1001;
+    Button mMaakFotoBtn;
+    ImageView mImageView;
+    Uri afbeelding_uri;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_camera);
+
+        //Assign uit de layout
+        mImageView = findViewById(R.id.image_view);
+        mMaakFotoBtn = findViewById(R.id.camera_maakFoto_btn);
+
+        //Op maakFotoKnop gedrukt
+        mMaakFotoBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                //Indien geen toestemming voor camera en opslag
+                if(checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_DENIED ||
+                        checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED){
+
+                    //Om toestemming vragen.
+                    String[] permission = {Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE};
+                    requestPermissions(permission, PERMISSION_CODE);
+                }else{
+                    //Heeft toestemming
+                    openCamera();
+                }
+            }
+        });
+
+    }
+
+    private void openCamera() {
+        //Camera intent & gemaakte afbeelding opslaan
+        ContentValues values = new ContentValues();
+        values.put(MediaStore.Images.Media.DESCRIPTION, "Project-D");
+        afbeelding_uri = getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
+
+        Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, afbeelding_uri);
+        startActivityForResult(cameraIntent, IMAGE_CAPTURE_CODE);
+    }
+
+    //Resultaat van gevraagde toestemming afhandelen.
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        switch (requestCode){
+            case PERMISSION_CODE: {
+                if(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED){
+                    openCamera();
+                }else{
+                    Toast.makeText(this, "Benodigde toestemming geweigerd.", Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        //Afbeelding met camera gemaakt, toon in imageView.
+        if(resultCode == RESULT_OK){
+            mImageView.setImageURI(afbeelding_uri);
+        }
+    }
+}

--- a/AndroidApplicatie/app/src/main/res/drawable/ic_imageph_rose_24dp.xml
+++ b/AndroidApplicatie/app/src/main/res/drawable/ic_imageph_rose_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFEEEE"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/AndroidApplicatie/app/src/main/res/layout/activity_camera.xml
+++ b/AndroidApplicatie/app/src/main/res/layout/activity_camera.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    tools:context=".CameraActivity">
+
+    <!--Image view waar gemaakte foto getoont zal worden. -->
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/image_view"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_imageph_rose_24dp"
+        android:layout_width="300dp"
+        android:layout_height="400dp" />
+
+    <!--Knop -->
+    <Button
+        android:id="@+id/camera_maakFoto_btn"
+        android:text="Maak foto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+
+</LinearLayout>


### PR DESCRIPTION
Wanneer op de  "maak foto" knop gedrukt wordt, eerst controleren of gebruiker toestemming gegeven heeft voor opslag en gebruik van camera. Indien geen toestemming toestemming vragen, wel toestemming dan via een intent naar camera switchen. Gebruiker kan een foto maken en deze behouden of weggooien. Indien behouden wordt de afbeelding lokaal opgeslagen en in de imageview getoond.